### PR TITLE
Sum of lepton charges and asymmetric binning

### DIFF
--- a/pythonStacker/createHistograms.py
+++ b/pythonStacker/createHistograms.py
@@ -66,7 +66,7 @@ def parse_arguments() -> argparse.Namespace:
 
 
 def prepare_histogram(data, wgts, variable: Variable):
-    hist_content, binning, hist_unc = src.histogram_w_unc_flow(ak.to_numpy(data), range=variable.range, wgts=ak.to_numpy(wgts), nbins=variable.nbins)
+    hist_content, binning, hist_unc = src.histogram_w_unc_flow(ak.to_numpy(data), axisrange=variable.range, wgts=ak.to_numpy(wgts), nbins=variable.nbins)
     return hist_content, binning, hist_unc
 
 

--- a/pythonStacker/plotHistogramsRedo.py
+++ b/pythonStacker/plotHistogramsRedo.py
@@ -38,7 +38,7 @@ def parse_arguments():
     parser.add_argument("--BSM_fullbkg", dest="BSM_fullbkg", action="store_true", default=False)
     parser.add_argument("--SBRatio", dest="SBRatio", action="store_true", default=False)
     parser.add_argument("--shapes", dest="shapes", action="store_true", default=False)
-    parser.add_argument("--suffix", action="store", default="_")
+    parser.add_argument("--suffix", action="store", default="")
 
     arguments.add_settingfiles(parser)
     arguments.select_specifics(parser)
@@ -115,7 +115,6 @@ def plot_histograms_base(axis, histograms: dict, variable: Variable, processes: 
     sum_of_content = np.zeros(variable.nbins)
 
     binning = generate_binning(variable.range, variable.nbins)
-
     for name, info in processes.items():
         content = np.zeros(variable.nbins)
         for year in years:
@@ -258,7 +257,8 @@ def plot_BSM_line(axis, histograms, variable: Variable, years, models: list, mas
 
 def finalize_plot(figure, axes, variable: Variable, plotdir: str, plotlabel=""):
     for ax in axes:
-        ax.set_xlim(variable.range)
+        # Not assuming a list with 2 entries ensures variable range doesn't clash with xlim setting 
+        ax.set_xlim(variable.range[0], variable.range[-1])
 
     axes[-1].set_xlabel(variable.axis_label)
     axes[0].text(0.049, 0.76, plotlabel, transform=axes[0].transAxes)

--- a/pythonStacker/settingfiles/Datacards/2016_SM.json
+++ b/pythonStacker/settingfiles/Datacards/2016_SM.json
@@ -66,7 +66,7 @@
             "prettyname": "CR4LZ"
         },
         "CR-3L-2J1B": {
-            "variable": "N_MedBjets_CR3Lothers",
+            "variable": "SumCharges_CR3Lothers",
             "prettyname": "CR3LNP"
         }
     }

--- a/pythonStacker/settingfiles/Datacards/2017_SM.json
+++ b/pythonStacker/settingfiles/Datacards/2017_SM.json
@@ -66,7 +66,7 @@
             "prettyname": "CR4LZ"
         },
         "CR-3L-2J1B": {
-            "variable": "N_MedBjets_CR3Lothers",
+            "variable": "SumCharges_CR3Lothers",
             "prettyname": "CR3LNP"
         }
     }

--- a/pythonStacker/settingfiles/Datacards/2018_SM.json
+++ b/pythonStacker/settingfiles/Datacards/2018_SM.json
@@ -66,7 +66,7 @@
             "prettyname": "CR4LZ"
         },
         "CR-3L-2J1B": {
-            "variable": "N_MedBjets_CR3Lothers",
+            "variable": "SumCharges_CR3Lothers",
             "prettyname": "CR3LNP"
         }
     }

--- a/pythonStacker/settingfiles/Uncertainties/2017_yukawa.json
+++ b/pythonStacker/settingfiles/Uncertainties/2017_yukawa.json
@@ -493,7 +493,7 @@
         "pretty_name": "tttw_norm",
         "technical_name": "cross_section_tttW",
         "channels": "all",
-        "processes": "tttw",
+        "processes": "tttW",
         "rate": "0.846/1.162",
         "type": "flat"
     }

--- a/pythonStacker/settingfiles/Uncertainties/base_ext.json
+++ b/pythonStacker/settingfiles/Uncertainties/base_ext.json
@@ -319,7 +319,7 @@
         "type": "weight"
     },
     "btag_hf_stats1_16PreVFP": {
-        "aliasDown": "nominalWeight * expDown[:, 10]", 
+        "aliasDown": "nominalWeight * expDown[:, 9]", 
         "aliasUp": "nominalWeight * expUp[:, 9]", 
         "technical_name": "CMS_btag_shape_hfstats1_2016preVFP",
         "processes": "MCOnly", 
@@ -330,7 +330,7 @@
     }, 
     "btag_hf_stats2_16PreVFP": {
         "aliasDown": "nominalWeight * expDown[:, 10]", 
-        "aliasUp": "nominalWeight * expUp[:, 9]", 
+        "aliasUp": "nominalWeight * expUp[:, 10]", 
         "technical_name": "CMS_btag_shape_hfstats2_2016preVFP",
         "processes": "MCOnly", 
         "channels": "all", 
@@ -339,7 +339,7 @@
         "eraspecific": "16PreVFP"
     }, 
     "btag_hf_stats1_16PostVFP": {
-        "aliasDown": "nominalWeight * expDown[:, 10]", 
+        "aliasDown": "nominalWeight * expDown[:, 9]", 
         "aliasUp": "nominalWeight * expUp[:, 9]", 
         "technical_name": "CMS_btag_shape_hfstats1_2016postVFP",
         "processes": "MCOnly", 
@@ -350,7 +350,7 @@
     }, 
     "btag_hf_stats2_16PostVFP": {
         "aliasDown": "nominalWeight * expDown[:, 10]", 
-        "aliasUp": "nominalWeight * expUp[:, 9]", 
+        "aliasUp": "nominalWeight * expUp[:, 10]", 
         "technical_name": "CMS_btag_shape_hfstats2_2016postVFP",
         "processes": "MCOnly", 
         "channels": "all", 
@@ -739,9 +739,7 @@
         "processes": [
             "ttW",
             "ttZ",
-            "ttH",
-            "tttt",
-            "ttt"
+            "ttH"
         ],
         "technical_name": "CMS_TOP24008_AddBJets_",
         "type": "weight",

--- a/pythonStacker/settingfiles/Variables/CR-3L-others.json
+++ b/pythonStacker/settingfiles/Variables/CR-3L-others.json
@@ -38,5 +38,13 @@
         "branch_name": "bTagWP",
         "method_name": "btag_tight",
         "channels": ["CR-3L-2J1B"]
+    },
+    "SumCharges_CR3Lothers": {
+        "range": [-1.5, 1.5],
+        "nbins": 2,
+        "axis_label": "$Sum charges$",
+        "branch_name": "ThisDoesLiterallyNotMatter",
+        "method_name": "sum_of_lepton_charges",
+        "channels": ["CR-3L-2J1B"]
     }
 }

--- a/pythonStacker/settingfiles/Variables/SR-2L.json
+++ b/pythonStacker/settingfiles/Variables/SR-2L.json
@@ -7,6 +7,14 @@
         "method_name": "sum_branch",
         "channels": ["SR-2L"]
     },
+    "HT_SR2L_asymm" : {
+        "range": [200.0, 700.0, 1600.0],
+        "nbins": 2,
+        "axis_label": "$H_T$",
+        "branch_name": "jetPt",
+        "method_name": "sum_branch",
+        "channels": ["SR-2L"]
+    },
     "LT_SR2L" : {
         "range": [250.0, 1400.0],
         "nbins": 23,

--- a/pythonStacker/src/__init__.py
+++ b/pythonStacker/src/__init__.py
@@ -14,17 +14,22 @@ Some general tools to create histograms
 """
 
 
-def generate_binning(range, nbins):
-    raw_bins = np.linspace(range[0], range[1], nbins + 1)
+def generate_binning(axisrange, nbins):
+    if len(axisrange) > 2:
+        # custom binning
+        # ensure its an array
+        raw_bins = np.array(axisrange)
+    else:
+        raw_bins = np.linspace(axisrange[0], axisrange[1], nbins + 1)
     return raw_bins
 
 
-def histogram_w_flow(data, range, wgts, nbins):
+def histogram_w_flow(data, axisrange, wgts, nbins):
     """
     Creates a numpy histogram but takes into account the under- and overflow.
     """
 
-    raw_bins = np.linspace(range[0], range[1], nbins + 1)
+    raw_bins = generate_binning(axisrange, nbins)
     use_bins = [np.array([-np.inf]), raw_bins, np.array([np.inf])]
     use_bins = np.concatenate(use_bins)
 
@@ -36,7 +41,7 @@ def histogram_w_flow(data, range, wgts, nbins):
     return binned_data, raw_bins
 
 
-def histogram_w_unc_flow(data, range, wgts, nbins):
+def histogram_w_unc_flow(data, axisrange, wgts, nbins):
     """
     Uses:
         - the data to bin
@@ -51,7 +56,7 @@ def histogram_w_unc_flow(data, range, wgts, nbins):
     Creates a numpy histogram. Takes into account over- and underflow. Calculates the MC uncertainties.
     """
 
-    raw_bins = np.linspace(range[0], range[1], nbins + 1)
+    raw_bins = generate_binning(axisrange, nbins)
     use_bins = [np.array([-np.inf]), raw_bins, np.array([np.inf])]
     use_bins = np.concatenate(use_bins)
 

--- a/pythonStacker/src/variables/__init__.py
+++ b/pythonStacker/src/variables/__init__.py
@@ -58,6 +58,13 @@ def count_btag_tight(tree: uproot.TTree, branchname: str, selection: str):
     return count_btag(tree, branchname, selection, 3)
 
 
+def sum_of_lepton_charges(tree: uproot.TTree, branchname: str, selection: str):
+    variables = tree.arrays(["electronCharge", "muonCharge"], cut=selection)
+    charges = ak.concatenate([variables.electronCharge, variables.muonCharge], axis=1)
+    final_var = ak.sum(charges, axis=1)
+    return ak.to_numpy(final_var)
+
+
 def get_method_from_str(method: str):
     tmp = {
         "load": load_variable,
@@ -67,6 +74,7 @@ def get_method_from_str(method: str):
         "sum_branch": sum_branch,
         "btag_tight": count_btag_tight,
         "btag_med": count_btag_med,
-        "btag_loose": count_btag_loose
+        "btag_loose": count_btag_loose,
+        "sum_of_lepton_charges": sum_of_lepton_charges
     }
     return tmp[method]


### PR DESCRIPTION
Sum of lepton charges added as a variable for CR-3L-2J1B. Added variable binning as an option (see SR-2L HT asymm as an example). Tested in plotting + DCs, all works smoothly.

Additionally tweaked some small mistakes in base_ext.json uncertainty settings